### PR TITLE
Reorganization of project, added tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/edgexfoundry-holding/go-mod-core-security
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.0-20190513185229-24a36f294d12 // indirect
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/mux v1.7.1
 )

--- a/pkg/client_test.go
+++ b/pkg/client_test.go
@@ -12,18 +12,36 @@
  * the License.
  *******************************************************************************/
 
-package types
+package pkg
 
-// Defines the valid secret store providers.
-const (
-	VaultProvider = "vault"
-	HTTPProvider  = "http"
+import (
+	"testing"
 )
 
-const (
-	CoreSecurityServiceKey = "edgex-core-security"
-	VaultToken             = "X-Vault-Token"
-	ConfigFileName         = "configuration.toml"
-	ConfigDirectory        = "./res"
-	ConfigDirEnv           = "EDGEX_CONF_DIR"
-)
+func TestNewSecretClient(t *testing.T) {
+	cfgHttp := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http"}
+	cfgNoop := SecretConfig{Host: "localhost", Port: 8080, Protocol: "mqtt"}
+
+	tests := []struct {
+		name      string
+		cfg       SecretConfig
+		expectErr bool
+	}{
+		{"newHttp", cfgHttp, false},
+		{"newNoop", cfgNoop, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewSecretClient(tt.cfg)
+			if err != nil {
+				if !tt.expectErr {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				if tt.expectErr {
+					t.Errorf("did not receive expected error: %s", tt.name)
+				}
+			}
+		})
+	}
+}

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -12,13 +12,24 @@
  * the License.
  *******************************************************************************/
 
-package http
+// Package types defines structs that will be used frequently in the codebase, both internal and external.
+package pkg
 
-import (
-	"os"
-	"testing"
-)
+import "fmt"
 
-func TestMain(m *testing.M) {
-	os.Exit(m.Run())
+type SecretConfig struct {
+	Host           string
+	Port           int
+	Path           string
+	Protocol       string
+	Authentication AuthenticationInfo
+}
+
+func (c SecretConfig) BuildURL() (path string) {
+	return fmt.Sprintf("%s://%s:%v%s", c.Protocol, c.Host, c.Port, c.Path)
+}
+
+type AuthenticationInfo struct {
+	AuthType  string
+	AuthToken string
 }

--- a/pkg/config_test.go
+++ b/pkg/config_test.go
@@ -12,27 +12,28 @@
  * the License.
  *******************************************************************************/
 
-// Package types defines structs that will be used frequently in the codebase, both internal and external.
-package types
+package pkg
 
-type SecretConfig struct {
-	Host           string
-	Port           string
-	Path           string
-	Authentication AuthenticationInfo
-}
+import "testing"
 
-func (c SecretConfig) BuildURL() (path string) {
-	if c.Path == "" {
-		path = "http://" + c.Host + ":" + c.Port + "/"
-	} else {
-		path = "http://" + c.Host + ":" + c.Port + "/" + c.Path
+func TestBuildUrl(t *testing.T) {
+	cfgNoPath := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http"}
+	cfgWithPath := SecretConfig{Host: "localhost", Port: 8080, Protocol: "http", Path: "/ping"}
+
+	tests := []struct {
+		name string
+		cfg  SecretConfig
+		path string
+	}{
+		{"validNoPath", cfgNoPath, "http://localhost:8080"},
+		{"validWithPath", cfgWithPath, "http://localhost:8080/ping"},
 	}
-	return path
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			val := tt.cfg.BuildURL()
+			if val != tt.path {
+				t.Errorf("%s unexpected path %s", tt.name, val)
+			}
+		})
+	}
 }
-
-type AuthenticationInfo struct {
-	AuthType  string
-	AuthToken string
-}
-

--- a/pkg/constants.go
+++ b/pkg/constants.go
@@ -12,11 +12,18 @@
  * the License.
  *******************************************************************************/
 
-// Package interfaces defines the contracts that must be implemented by services.
-package interfaces
+package pkg
 
-type SecretClient interface {
-	GetValue(key string) (string, error)
-	SetValue(key string, value string) error
-	DeleteValue(key string) error
-}
+// Defines the valid secret store providers.
+const (
+	VaultProvider = "vault"
+	HTTPProvider  = "http"
+)
+
+const (
+	CoreSecurityServiceKey = "edgex-core-security"
+	VaultToken             = "X-Vault-Token"
+	ConfigFileName         = "configuration.toml"
+	ConfigDirectory        = "./res"
+	ConfigDirEnv           = "EDGEX_CONF_DIR"
+)

--- a/pkg/interfaces.go
+++ b/pkg/interfaces.go
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright 2019 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *******************************************************************************/
+
+// Package interfaces defines the contracts that must be implemented by services.
+package pkg
+
+// SecretClient is an interface defining the basic operations for interacting with a secrets store
+type SecretClient interface {
+
+	// GetValue returns a value for the supplied key from the secrets store
+	GetValue(key string) (string, error)
+
+	// SetValue will persist a given key/value pair in the secrets store
+	SetValue(key string, value string) error
+
+	// DeleteValue will remove a key and its associated value from the secrets store
+	DeleteValue(key string) error
+}


### PR DESCRIPTION
Fix #8
Fix #9

- Reorg of all code into single exportable /pkg folder
- Uncapitalized types not meant for export
- Added tests for SecretConfig and NewSecretClient. Further testing could
be achieved by hiding the tight http request integration behind an
interface that is provided to the HttpClient. In this way, requests can
be easily simulated. OR, if preferred, use the httptest package to
spin up a mock HTTP server for testing.

I think that with the above changes this module can be pulled into the
edgexfoundry organization. However it should probably be renamed to
something like go-mod-security-client.

Signed-off-by: Trevor Conn <trevor_conn@dell.com>